### PR TITLE
Update setupsos

### DIFF
--- a/setupsos
+++ b/setupsos
@@ -35,19 +35,19 @@ do
 	touch $PWD/archive/$i
 	rm -f $i
 done
-for i in `ls -d */`; 
+for i in 'ls -d */'; 
 	do 
-	if [ -e $i/date ]; then
+	if [ -e "$i/date" ]; then
 		DESTFILE=`cat $i/hostname | awk -F '.' '/^[[:alpha:]]/ {print $1}'`-`cat $i/date | grep '^[a-Z]' | tr -s ' ' | sed 's/ /-/g' | awk -F "-" '{print $NF"-"$2"-"$3"-"$4}'`
 		if [ ! -d $DESTFILE ]; then
 			mv $i $DESTFILE 
 		fi
 	fi
 done
-for i in `ls -d */`
+for i in 'ls -d */'
 do
 	export HOSTNAMEFILE="$i/hostname"
-	if [ -e $HOSTNAMEFILE ]; then
+	if [ -e "$HOSTNAMEFILE" ]; then
 		export SYSHOSTNAME=`cat $HOSTNAMEFILE | cut -d '.' -f 1`
 	else
 		continue


### PR DESCRIPTION
Running grab2 script would generate the following errors from the setupsos script:

ls: cannot access '\*/': No such file or directory
ls: cannot access '\*/': No such file or directory

so I put these commands in single quotes instead of backticks. Then, setupsos would throw these errors:

/path/to/script/setupsos.sh: line 40: [: too many arguments
/path/to/script/setupsos.sh: line 50: [: too many arguments

so I placed the directory names in those if statements in double quotes. Script no longer gives any error messages.